### PR TITLE
support for throwing errors from the lua code

### DIFF
--- a/config.go
+++ b/config.go
@@ -5,7 +5,6 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 
@@ -130,23 +129,3 @@ var (
 	ErrNoExtraConfig    = errors.New("no extra config")
 	ErrWrongExtraConfig = errors.New("wrong extra config")
 )
-
-type ErrWrongChecksumType string
-
-func (e ErrWrongChecksumType) Error() string {
-	return "lua: wrong cheksum type for source " + string(e)
-}
-
-type ErrWrongChecksum struct {
-	Source, Actual, Expected string
-}
-
-func (e ErrWrongChecksum) Error() string {
-	return fmt.Sprintf("lua: wrong cheksum for source %s. have: %v, want: %v", e.Source, e.Actual, e.Expected)
-}
-
-type ErrUnknownSource string
-
-func (e ErrUnknownSource) Error() string {
-	return "lua: unable to load required source " + string(e)
-}

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,87 @@
+package lua
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/alexeyco/binder"
+)
+
+type ErrWrongChecksumType string
+
+func (e ErrWrongChecksumType) Error() string {
+	return "lua: wrong cheksum type for source " + string(e)
+}
+
+type ErrWrongChecksum struct {
+	Source, Actual, Expected string
+}
+
+func (e ErrWrongChecksum) Error() string {
+	return fmt.Sprintf("lua: wrong cheksum for source %s. have: %v, want: %v", e.Source, e.Actual, e.Expected)
+}
+
+type ErrUnknownSource string
+
+func (e ErrUnknownSource) Error() string {
+	return "lua: unable to load required source " + string(e)
+}
+
+var errNeedsArguments = errors.New("need arguments")
+
+type ErrInternal string
+
+func (e ErrInternal) Error() string {
+	return string(e)
+}
+
+type ErrInternalHTTP struct {
+	msg  string
+	code int
+}
+
+func (e ErrInternalHTTP) StatusCode() int {
+	return e.code
+}
+
+func (e ErrInternalHTTP) Error() string {
+	return e.msg
+}
+
+func ToError(e error) error {
+	if e == nil {
+		return e
+	}
+
+	if _, ok := e.(*binder.Error); !ok {
+		return e
+	}
+
+	originalMsg := e.Error()
+	start := strings.Index(originalMsg, ":")
+
+	if l := len(originalMsg); originalMsg[l-1] == ')' && originalMsg[l-5] == '(' {
+		code, err := strconv.Atoi(originalMsg[l-4 : l-1])
+		if err != nil {
+			code = 500
+		}
+		return ErrInternalHTTP{msg: originalMsg[start+2 : l-6], code: code}
+	}
+
+	return ErrInternal(originalMsg[start+2:])
+}
+
+func RegisterErrors(b *binder.Binder) {
+	b.Func("custom_error", func(c *binder.Context) error {
+		switch c.Top() {
+		case 0:
+			return errNeedsArguments
+		case 1:
+			return errors.New(c.Arg(1).String())
+		default:
+			return fmt.Errorf("%s (%d)", c.Arg(1).String(), int(c.Arg(2).Number()))
+		}
+	})
+}

--- a/router/gin/lua.go
+++ b/router/gin/lua.go
@@ -61,6 +61,7 @@ func process(c *gin.Context, cfg lua.Config) error {
 		IncludeGoStackTrace: true,
 	})
 
+	lua.RegisterErrors(b)
 	registerCtxTable(c, b)
 
 	for _, source := range cfg.Sources {

--- a/router/gin/lua.go
+++ b/router/gin/lua.go
@@ -46,6 +46,11 @@ func HandlerFactory(l logging.Logger, next krakendgin.HandlerFactory) krakendgin
 
 		return func(c *gin.Context) {
 			if err := process(c, cfg); err != nil {
+				err = lua.ToError(err)
+				if errhttp, ok := err.(errHTTP); ok {
+					c.AbortWithError(errhttp.StatusCode(), err)
+					return
+				}
 				c.AbortWithError(http.StatusInternalServerError, err)
 				return
 			}
@@ -53,6 +58,11 @@ func HandlerFactory(l logging.Logger, next krakendgin.HandlerFactory) krakendgin
 			handlerFunc(c)
 		}
 	}
+}
+
+type errHTTP interface {
+	error
+	StatusCode() int
 }
 
 func process(c *gin.Context, cfg lua.Config) error {

--- a/router/mux/lua.go
+++ b/router/mux/lua.go
@@ -54,6 +54,12 @@ func HandlerFactory(l logging.Logger, next mux.HandlerFactory, pe mux.ParamExtra
 
 		return func(w http.ResponseWriter, r *http.Request) {
 			if err := process(r, pe, cfg); err != nil {
+				err = lua.ToError(err)
+				if errhttp, ok := err.(errHTTP); ok {
+					http.Error(w, err.Error(), errhttp.StatusCode())
+					return
+				}
+
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
@@ -61,6 +67,11 @@ func HandlerFactory(l logging.Logger, next mux.HandlerFactory, pe mux.ParamExtra
 			handlerFunc(w, r)
 		}
 	}
+}
+
+type errHTTP interface {
+	error
+	StatusCode() int
 }
 
 func process(r *http.Request, pe mux.ParamExtractor, cfg lua.Config) error {

--- a/router/mux/lua.go
+++ b/router/mux/lua.go
@@ -69,6 +69,7 @@ func process(r *http.Request, pe mux.ParamExtractor, cfg lua.Config) error {
 		IncludeGoStackTrace: true,
 	})
 
+	lua.RegisterErrors(b)
 	registerRequestTable(r, pe, b)
 
 	for _, source := range cfg.Sources {


### PR DESCRIPTION
This PR introduces a new helper able to abort the execution throwing an internal error or a http error (with status code).

This won't cover https://github.com/devopsfaith/krakend-ce/issues/204 100% but it is a first step in such direction