### PR TITLE
del method added to lua tables

### DIFF
--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -119,6 +119,7 @@ func TestProxyFactory(t *testing.T) {
 					"comment": "some",
 				},
 			},
+			"to_be_removed": 123456,
 		},
 		Metadata: proxy.Metadata{},
 		Io:       strings.NewReader("initial resp content"),
@@ -192,6 +193,7 @@ func TestProxyFactory(t *testing.T) {
 		responseData:set("more", data)
 		local bar = string.find('banana', 'an')
 		responseData:set("bar", bar)
+		responseData:del("to_be_removed")
 
 		resp:headers("Content-Type", "application/xml")
 		resp:statusCode(200)

--- a/proxy/response.go
+++ b/proxy/response.go
@@ -16,6 +16,7 @@ func registerResponseTable(resp *proxy.Response, b *binder.Binder) {
 	tab.Dynamic("get", tableGet)
 	tab.Dynamic("set", tableSet)
 	tab.Dynamic("len", tableLen)
+	tab.Dynamic("del", tableDel)
 	list := b.Table("luaList")
 	list.Dynamic("get", listGet)
 	list.Dynamic("set", listSet)
@@ -284,6 +285,18 @@ func listSet(c *binder.Context) error {
 		}
 	}
 
+	return nil
+}
+
+func tableDel(c *binder.Context) error {
+	if c.Top() != 2 {
+		return errNeedsArguments
+	}
+	tab, ok := c.Arg(1).Data().(*luaTable)
+	if !ok {
+		return errResponseExpected
+	}
+	delete(tab.data, c.Arg(2).String())
 	return nil
 }
 


### PR DESCRIPTION
this pr introduces a new dynamic method for the lua tables.
```
t:del("element")
```