### PR TITLE
Add del operation for lists

### DIFF
--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -118,6 +118,14 @@ func TestProxyFactory(t *testing.T) {
 					"id":      42,
 					"comment": "some",
 				},
+				map[string]interface{}{
+					"id":      99,
+					"comment": "to be removed",
+				},
+				map[string]interface{}{
+					"id":      0,
+					"comment": "last",
+				},
 			},
 			"to_be_removed": 123456,
 		},
@@ -179,6 +187,10 @@ func TestProxyFactory(t *testing.T) {
 		data["supu"] = {}
 		data["supu"]["tupu"] = "some"
 		data["supu"]["original"] = responseData:get("ok")
+
+		local original_collection = responseData:get("collection")
+		original_collection:del(2)
+		responseData:set("collection", original_collection)
 		local col = responseData:get("collection")
 		data["collection_size"] = col:len()
 
@@ -251,16 +263,21 @@ func TestProxyFactory(t *testing.T) {
 		{
 			"comment": "some",
 			"id": 42
+		},
+		{
+			"comment": "last",
+			"id": 0
 		}
 	],
 	"foo": "some_new_value",
 	"more": {
 		"bar": 120,
-		"collection_size": 2,
+		"collection_size": 3,
 		"foobar": true,
 		"ids": {
 			"1": 1,
-			"2": 42
+			"2": 42,
+			"3": 0
 		},
 		"supu": {
 			"original": true,

--- a/proxy/response.go
+++ b/proxy/response.go
@@ -21,6 +21,7 @@ func registerResponseTable(resp *proxy.Response, b *binder.Binder) {
 	list.Dynamic("get", listGet)
 	list.Dynamic("set", listSet)
 	list.Dynamic("len", listLen)
+	list.Dynamic("del", listDel)
 
 	r := &response{resp}
 	if r.Metadata.Headers == nil {
@@ -297,6 +298,28 @@ func tableDel(c *binder.Context) error {
 		return errResponseExpected
 	}
 	delete(tab.data, c.Arg(2).String())
+	return nil
+}
+
+func listDel(c *binder.Context) error {
+	if c.Top() != 2 {
+		return errNeedsArguments
+	}
+	tab, ok := c.Arg(1).Data().(*luaList)
+	if !ok {
+		return errResponseExpected
+	}
+	key := int(c.Arg(2).Number())
+	if key < 0 || key >= len(tab.data) {
+		return nil
+	}
+
+	last := len(tab.data) - 1
+	if key < last {
+		copy(tab.data[key:], tab.data[key+1:])
+	}
+	tab.data[last] = nil
+	tab.data = tab.data[:last]
 	return nil
 }
 


### PR DESCRIPTION
this PR introduces the `del` operation for lists:

```
local original_collection = responseData:get("collection")
original_collection:del(2)
responseData:set("collection", original_collection)
```